### PR TITLE
Export irregex-fold/chunked in chicken and guile

### DIFF
--- a/irregex-chicken.scm
+++ b/irregex-chicken.scm
@@ -5,7 +5,8 @@
   irregex? irregex-match-data?
   irregex-new-matches irregex-reset-matches!
   irregex-search irregex-search/matches irregex-match
-  irregex-search/chunked irregex-match/chunked make-irregex-chunker
+  irregex-search/chunked irregex-match/chunked
+  irregex-fold/chunked make-irregex-chunker
   irregex-match-substring irregex-match-subchunk
   irregex-match-start-chunk irregex-match-start-index
   irregex-match-end-chunk irregex-match-end-index

--- a/irregex-guile.scm
+++ b/irregex-guile.scm
@@ -6,7 +6,7 @@
 	    maybe-string->sre irregex?  irregex-match-data?
 	    irregex-new-matches irregex-reset-matches!  irregex-search
 	    irregex-search/matches irregex-match
-	    irregex-search/chunked irregex-match/chunked
+	    irregex-search/chunked irregex-match/chunked irregex-fold/chunked
 	    make-irregex-chunker irregex-match-substring
 	    irregex-match-subchunk irregex-match-start-source
 	    irregex-match-start-index irregex-match-end-source


### PR DESCRIPTION
I noticed while learning this library today that irregex-fold/chunked is not exported. It's described in the manual so I assume it was intended to.