### PR TITLE
Prevent combinatorial explosion in backtracking match for {n,m} expressions

### DIFF
--- a/benchmarks/re-benchmarks.txt
+++ b/benchmarks/re-benchmarks.txt
@@ -32,5 +32,8 @@ email	(")?([[:alnum:]!#$%&'*+/=?^_`{|}~-])+(\.[[:alnum:]!#$%&'*+/=?^_`{|}~-]+)*(
 
 # Expensive examples which may hang or explode
 backtracker	a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa	x	100	100
-expontential dfa	a[ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab]	abbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb	b	1	100
-#backtracker + expontential dfa	a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab]	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbb	b	1	100
+exponential dfa	a[ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab]	abbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb	b	1	100
+#backtracker + exponential dfa	a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab][ab]	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbb	b	1	100
+
+# Found by Caolan McMahon
+exponential backtracking for repeating pattern	[a-z]{0,42}	testing@	b	1	1

--- a/irregex.doc
+++ b/irregex.doc
@@ -798,7 +798,7 @@ possible.
 
 \section{License}
 
-Copyright (c) 2005-2012 Alex Shinn
+Copyright (c) 2005-2015 Alex Shinn
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/re-tests.txt
+++ b/re-tests.txt
@@ -73,6 +73,18 @@ a**	-	c	-	-
 (a+|b)*	ab	y	&-\1	ab-b
 (a+|b)+	ab	y	&-\1	ab-b
 (a+|b)?	ab	y	&-\1	a-a
+(a+|b){0,2}	ab	y	&-\1	ab-b
+(a+|b){1,2}	ab	y	&-\1	ab-b
+^(a+|b){1,2}$	ab	y	&-\1	ab-b
+^(a+|b){1,2}$	abc	n	-	-
+^(a+|b){0,1}$	ab	n	-	-
+\'(**? 0 2 ($ (or (+ #\a) #\b)))b	ab	y	&-\1	ab-a
+\'(**? 0 2 ($ (or (+ #\a) #\b)))b	aab	y	&-\1	aab-aa
+\'(**? 0 2 ($ (or (+ #\a) #\b)))b	abb	y	&-\1	ab-a
+^\'(**? 0 2 ($ (or (+ #\a) #\b)))b$	abb	y	&-\1	abb-b
+\'(**? 1 2 ($ (or (+ #\a) #\b)))b	b	n	-	-
+\'(**? 0 2 ($ (or (+ #\a) #\b)))ab	ab	y	&-\1	ab-
+\'(**? 2 3 ($ (or (+ #\a) #\b)))b	ab	n	-	-
 [^ab]*	cde	y	&	cde
 (^)*	-	c	-	-
 (ab|)*	-	c	-	-


### PR DESCRIPTION
The backtracking match for `{n,m}` matches (i.e., SRE's `**` and `**?`) will traverse the input factorial times for each potential match.  This results in an extremely pathological case, as found by Caolan McMahon.

I've added that case as a benchmark to `re-benchmarks.txt`.  It is similar to the one that's currently commented out, except we can obtain better performance by using the knowledge that the submatches are all the same.  For instance, the regular expression `a?b?c?` **must** be matched 9 times or so, because all of `""`, `"a"`, `"ab"`, `"abc"`, `"ac"`, `"b"`, `"bc"`" and `"c"` are possible candidates for matching.  Similarly, if `a{0,3}` is treated as `a?a?a?`, it will be tested against `""`, `"a"`, `"aa"`, `"aaa"`, `"aa"`, `"a"`, `"aa"` and `"a"`.  By not using the same backtracking strategy we can avoid testing the same sequence multiple times and just try an incremental length: `""`, `"a"`, `"aa"` and `"aaa"`.

The patch in this pull request attempts to implement this.  It's very tricky code, so I'm not 100% sure I did it correctly. There were no tests for this type of pattern yet, so I've added a few. Please check the code carefully and add more tests as you see fit.

BTW: Is there a PCRE style regex pattern for the SRE `**?` non-greedy version of {n,m}?  I resolved to the SRE escape in the tests, because I couldn't find one.