### PR TITLE
Handle zero count repetition pattern edge cases.

### DIFF
--- a/irregex.scm
+++ b/irregex.scm
@@ -3151,12 +3151,14 @@
                                     (if (>= count from)
                                         (next cnk init src str i end matches fail)
                                         (fail))))))))))
-                 (lambda (cnk init src str i end matches fail)
-                   ((body 1) cnk init src str i end matches
-                    (lambda ()
-                      (if (zero? from)
-                          (next cnk init src str i end matches fail)
-                          (fail)))))))))
+                 (if (and (zero? from) to (zero? to))
+                     next
+                     (lambda (cnk init src str i end matches fail)
+                       ((body 1) cnk init src str i end matches
+                        (lambda ()
+                          (if (zero? from)
+                              (next cnk init src str i end matches fail)
+                              (fail))))))))))
             ((**?)
              (cond
               ((or (and (number? (cadr sre))
@@ -3184,12 +3186,14 @@
                                              (fail)
                                              ((body (+ 1 count)) cnk init
                                               src str i end matches fail))))))))))
-                 (lambda (cnk init src str i end matches fail)
-                   (if (zero? from)
-                       (next cnk init src str i end matches
-                             (lambda ()
-                               ((body 1) cnk init src str i end matches fail)))
-                       ((body 1) cnk init src str i end matches fail)))))))
+                 (if (and (zero? from) to (zero? to))
+                     next
+                     (lambda (cnk init src str i end matches fail)
+                       (if (zero? from)
+                           (next cnk init src str i end matches
+                                 (lambda ()
+                                   ((body 1) cnk init src str i end matches fail)))
+                           ((body 1) cnk init src str i end matches fail))))))))
             ((word)
              (rec `(seq bow ,@(cdr sre) eow)))
             ((word+)

--- a/re-tests.txt
+++ b/re-tests.txt
@@ -73,8 +73,10 @@ a**	-	c	-	-
 (a+|b)*	ab	y	&-\1	ab-b
 (a+|b)+	ab	y	&-\1	ab-b
 (a+|b)?	ab	y	&-\1	a-a
+(a+|b){0,0}	ab	y	&-\1	-
 (a+|b){0,2}	ab	y	&-\1	ab-b
 (a+|b){1,2}	ab	y	&-\1	ab-b
+^(a+|b){0,0}$	a	n	-	-
 ^(a+|b){1,2}$	ab	y	&-\1	ab-b
 ^(a+|b){1,2}$	abc	n	-	-
 ^(a+|b){0,1}$	ab	n	-	-
@@ -87,6 +89,8 @@ a**	-	c	-	-
 ^(a+|b){0,2}?b$	abb	y	&-\1	abb-b
 ^(a+|b){0,2}?$	aab	y	&-\1	aab-b
 ^((a+)|(b)){0,2}?$	aaab	y	&-\1-\2-\3	aaab-b-aaa-b
+^(a+|b){0,0}?$	a	n	-	-
+(a+|b){0,0}?	ab	y	&-\1	-
 (a+|b){1,2}?b	b	n	-	-
 (a+|b){0,2}?ab	ab	y	&-\1	ab-
 (a+|b){2,3}?b	ab	n	-	-


### PR DESCRIPTION
One test from test-irregex-scsh.scm failed on this, but only the greedy
version is tested there.  Both cases have now been added to re-tests.txt