### PR TITLE
minor fixes (I hope) to doc and code of sre->string

### DIFF
--- a/irregex-utils.scm
+++ b/irregex-utils.scm
@@ -89,7 +89,7 @@
         (case (car x)
           ((: seq)
            (cond
-            ((and (pair? (cddr x)) (pair? (cddr x)) (not (eq? x obj)))
+            ((and (pair? (cdr x)) (pair? (cddr x)) (not (eq? x obj)))
              (display "(?:" out) (for-each lp (cdr x)) (display ")" out))
             (else (for-each lp (cdr x)))))
           ((submatch)

--- a/irregex.doc
+++ b/irregex.doc
@@ -781,7 +781,7 @@ doesn't help when irregex is able to build a DFA.
 
 \subsubsection*{(sre->string <sre>)}
 
-Convert an SRE to a POSIX-style regular expression string, if
+Convert an SRE to a PCRE-style regular expression string, if
 possible.
 
 \section{Roadmap}


### PR DESCRIPTION
In documentation of sre->string, 'POSIX' changed to 'PCRE' because I
believe PCRE syntax is what is used in its result.  Also, in code for
sre->string, there was a redundant (pair? (cddr x)) test which I
updated to (pair? (cdr x)) which seems to make more sense there.