### PR TITLE
Exclude vector-copy when importing (scheme base).

### DIFF
--- a/irregex.sld
+++ b/irregex.sld
@@ -15,5 +15,5 @@
           irregex-dfa irregex-dfa/search
           irregex-nfa irregex-flags irregex-lengths irregex-names
           irregex-num-submatches irregex-extract irregex-split)
-  (import (scheme base) (scheme char) (scheme cxr))
+  (import (except (scheme base) vector-copy) (scheme char) (scheme cxr))
   (include "irregex.scm"))


### PR DESCRIPTION
vector-copy is exported by (scheme base), and also definied in
irregex.scm, which leads to an error.  Perhaps it would be better to
use the (scheme base) version of vector-copy, but excluding
vector-copy from the (scheme base) import seems to be OK too.