### PR TITLE
Fix #26 by taking the max of the inserted state numbers

### DIFF
--- a/irregex.scm
+++ b/irregex.scm
@@ -2481,7 +2481,7 @@
                                            flags
                                            next))))
                           (and a
-                               (let ((c (add-state! (new-state-number a)
+                               (let ((c (add-state! (new-state-number (max a b))
                                                     '())))
                                  (nfa-add-epsilon! buf c a #f)
                                  (nfa-add-epsilon! buf c b #f)

--- a/test-irregex.scm
+++ b/test-irregex.scm
@@ -575,5 +575,14 @@
   ;; irregex-flags, irregex-lengths
   )
 
+(test-group "SRE representation edge cases"
+  ;; NFA compilation skipped alternative after empty sequence (#26, found by John Clements)
+  (test "empty sequence in \"or\""
+        ""
+        (irregex-match-substring (irregex-search `(or (seq) "foo") "")))
+  (test "alternative to empty sequence in \"or\""
+        "foo"
+        (irregex-match-substring (irregex-search `(or (seq) "foo") "foo"))))
+
 (test-end)
 


### PR DESCRIPTION
When compiling an NFA for an alternation expression, if the left part
of the expression is an empty sequence (but NOT when it is a literal
epsilon!), the new state added for the entire expression would get
the state number of the empty sequence (which is the same as the
state number preceding the expression).  This would have the effect
of dropping the right part of the expression in the NFA.  But there
would still be references to them, causing strange errors.

Instead, we must take the maximum of the two, because we never know
which of the two expressions inserts new states.