### PR TITLE
guile: Export *-chunk instead of *-source procedures.

### DIFF
--- a/irregex-guile.scm
+++ b/irregex-guile.scm
@@ -8,8 +8,8 @@
 	    irregex-search/matches irregex-match
 	    irregex-search/chunked irregex-match/chunked irregex-fold/chunked
 	    make-irregex-chunker irregex-match-substring
-	    irregex-match-subchunk irregex-match-start-source
-	    irregex-match-start-index irregex-match-end-source
+	    irregex-match-subchunk irregex-match-start-chunk
+	    irregex-match-start-index irregex-match-end-chunk
 	    irregex-match-end-index irregex-match-num-submatches
             irregex-match-names irregex-match-valid-index?
 	    irregex-fold irregex-replace irregex-replace/all


### PR DESCRIPTION
It looks like in commit aa01637c6f0ec5b9679fcc68da631872222989d7 the -source procedures were renamed to -chunk, but this was not reflected in the guile module definition.

* irregex-guile.scm (rx irregex): Export irregex-match-start-chunk instead of irregex-match-start-source and irregex-match-end-chunk instead of irregex-match-end-source.