### PR TITLE
tests: Split each test file into two parts.

### DIFF
--- a/tests/README
+++ b/tests/README
@@ -5,9 +5,14 @@ To execute all tests, run the following script:
     ./tests/all
 
 This script can be executed from any location, so both ./tests/all and ./all
-(assuming you are in tests directory) are valid invocations.
+(assuming you are in tests directory) are valid invocations.  Be aware that you
+need to have all necessary dependencies configured and available in your PATH.
+Assuming you are using Guix, you can run all tests in an appropriate environment
+like this:
+
+    guix shell -m manifest.scm -C -- ./tests/all
 
 To execute just a specific test suite, run the desired file from the root of the
 repository using the appropriate scheme interpret, so for example:
 
-    csi -s ./tests/test-irregex-utf8.scm
+    csi -s ./tests/chicken-irregex-utf8.scm

--- a/tests/all
+++ b/tests/all
@@ -6,7 +6,23 @@ root=$tdir/..
 
 cd -- "$root"
 
-for t in tests/test-*.scm; do
-	printf '* %s:\n' "$t"
-	csi -s "$t"
+# List of schemes to use.  For each scheme you need to provide a
+# interpret_SCHEME unary function invoking the interpret for a file passed in as
+# the argument.
+#
+# The script will execute interpret_SCHEME function for every file matching the
+# tests/SCHEME-*.scm glob pattern.
+schemes='
+	chicken
+'
+
+interpret_chicken() {
+	csi -s "$@"
+}
+
+for scheme in $schemes; do
+	for t in tests/$scheme-*.scm; do
+		printf '* %s:\n' "$t"
+		interpret_$scheme "$t"
+	done
 done

--- a/tests/chicken-cset.scm
+++ b/tests/chicken-cset.scm
@@ -1,0 +1,7 @@
+(cond-expand
+  (chicken-5 (import test (chicken irregex)))
+  (else (use test extras utils irregex)))
+
+(load "irregex.scm")
+(load "tests/test-cset.scm")
+(test-exit)

--- a/tests/chicken-irregex-from-gauche.scm
+++ b/tests/chicken-irregex-from-gauche.scm
@@ -1,0 +1,8 @@
+(cond-expand
+  (chicken-5 (import srfi-1 test))
+  (else (use srfi-1 test)))
+
+(load "irregex.scm")
+(load "irregex-utils.scm")
+(load "tests/test-irregex-from-gauche.scm")
+(test-exit)

--- a/tests/chicken-irregex-pcre.scm
+++ b/tests/chicken-irregex-pcre.scm
@@ -1,0 +1,7 @@
+(cond-expand
+  (chicken-5 (import test))
+  (else (use test extras utils)))
+
+(load "irregex.scm")
+(load "tests/test-irregex-pcre.scm")
+(test-exit)

--- a/tests/chicken-irregex-scsh.scm
+++ b/tests/chicken-irregex-scsh.scm
@@ -1,0 +1,7 @@
+(cond-expand
+  (chicken-5 (import test))
+  (else (use test)))
+
+(load "irregex.scm")
+(load "tests/test-irregex-scsh.scm")
+(test-exit)

--- a/tests/chicken-irregex-utf8.scm
+++ b/tests/chicken-irregex-utf8.scm
@@ -1,0 +1,7 @@
+(cond-expand
+  (chicken-5 (import test))
+  (else (use test extras utils)))
+
+(load "irregex.scm")
+(load "tests/test-irregex-utf8.scm")
+(test-exit)

--- a/tests/chicken-irregex.scm
+++ b/tests/chicken-irregex.scm
@@ -1,0 +1,11 @@
+(cond-expand
+ (chicken-5 (import test matchable (chicken format) (chicken port) (chicken io) (rename (chicken string) (string-intersperse string-join))))
+ (chicken (use test extras utils matchable))
+ (else
+  (import (scheme base) (scheme char) (scheme cxr)
+          (scheme file) (scheme load) (scheme write)
+          (srfi 130) (chibi match) (chibi test))))
+
+(load "irregex.scm")
+(load "tests/test-irregex.scm")
+(test-exit)

--- a/tests/test-cset.scm
+++ b/tests/test-cset.scm
@@ -3,12 +3,6 @@
 
 ;;; Some of these are based on Olin Shivers' SRFI 14 tests
 
-(cond-expand
-  (chicken-5 (import test (chicken irregex)))
-  (else (use test extras utils irregex)))
-
-(load "irregex.scm")
-
 (define (vowel? c) (member c '(#\a #\e #\i #\o #\u)))
 
 (test-begin)

--- a/tests/test-irregex-from-gauche.scm
+++ b/tests/test-irregex-from-gauche.scm
@@ -1,11 +1,5 @@
 ;;; This test suite is derived from Gauche's regex tests.
 
-(cond-expand
-  (chicken-5 (import srfi-1 test))
-  (else (use srfi-1 test)))
-(load "irregex.scm")
-(load "irregex-utils.scm")
-
 (define-syntax let1
   (syntax-rules ()
     ((let1 var val body ...)

--- a/tests/test-irregex-pcre.scm
+++ b/tests/test-irregex-pcre.scm
@@ -1,8 +1,3 @@
-(cond-expand
-  (chicken-5 (import test))
-  (else (use test extras utils)))
-(load "irregex.scm")
-
 (test-begin)
 
 (test-assert (irregex-search "\\x41," "A,"))

--- a/tests/test-irregex-scsh.scm
+++ b/tests/test-irregex-scsh.scm
@@ -1,10 +1,5 @@
 ;;; Adapted from SCSH SRE tests by Christoph Hetz
 
-(cond-expand
-  (chicken-5 (import test))
-  (else (use test)))
-(load "irregex.scm")
-
 (define-syntax rx
   (syntax-rules ()
     ((rx sre) `sre)

--- a/tests/test-irregex-utf8.scm
+++ b/tests/test-irregex-utf8.scm
@@ -1,8 +1,3 @@
-(cond-expand
-  (chicken-5 (import test))
-  (else (use test extras utils)))
-(load "irregex.scm")
-
 (test-begin)
 
 (test-assert (irregex-search "(?u:<..>)" "<漢字>"))

--- a/tests/test-irregex.scm
+++ b/tests/test-irregex.scm
@@ -1,13 +1,3 @@
-(cond-expand
- (chicken-5 (import test matchable (chicken format) (chicken port) (chicken io) (rename (chicken string) (string-intersperse string-join))))
- (chicken (use test extras utils matchable))
- (else
-  (import (scheme base) (scheme char) (scheme cxr)
-          (scheme file) (scheme load) (scheme write)
-          (srfi 130) (chibi match) (chibi test))))
-
-(load "irregex.scm")
-
 (define (cat . args)
   (let ((out (open-output-string)))
     (for-each (lambda (x) (display x out)) args)


### PR DESCRIPTION
Each test has a dialect-specific setup part (loading dependencies, ...) and actually portable part containing the test logic.  This commit splits those parts into two separate file, so that the test logic can be reused between multiple dialects.

The test logic is always in test-NAME.scm file, while the dialect specific part is in DIALECT-NAME.scm file.  So, for example we now have tests/test-cset.scm and tests/chicken-cset.scm.

* tests/README: Adjust to the new layout.  Add a note about Guix.
* tests/all: Modify to be able to run tests for all listed scheme dialects.
* tests/chicken-cset.scm, tests/chicken-irregex-from-gauche.scm,
tests/chicken-irregex-pcre.scm,
tests/chicken-irregex-scsh.scm,
tests/chicken-irregex-utf8.scm,
tests/chicken-irregex.scm: New files.
* tests/test-cset.scm, tests/test-irregex-from-gauche.scm,
tests/test-irregex-pcre.scm,
tests/test-irregex-scsh.scm,
tests/test-irregex-utf8.scm,
tests/test-irregex.scm: Remove the setup code.