### PR TITLE
tests: Add suite-name to test-begin.

### DIFF
--- a/tests/test-cset.scm
+++ b/tests/test-cset.scm
@@ -5,7 +5,7 @@
 
 (define (vowel? c) (member c '(#\a #\e #\i #\o #\u)))
 
-(test-begin)
+(test-begin "cset")
 
 (test-assert
  (cset=? (plist->cset '(#\a #\a #\e #\e #\i #\i #\o #\o #\u #\u))

--- a/tests/test-irregex-from-gauche.scm
+++ b/tests/test-irregex-from-gauche.scm
@@ -37,7 +37,7 @@
                 (irregex-match-substring match i)))
           (else #f))))
 
-(test-begin)
+(test-begin "from-gauche")
 
 (test "a(b)c" '("abc" "b")
        (match&list "a(b)c" "abc"))

--- a/tests/test-irregex-pcre.scm
+++ b/tests/test-irregex-pcre.scm
@@ -1,4 +1,4 @@
-(test-begin)
+(test-begin "pcre")
 
 (test-assert (irregex-search "\\x41," "A,"))
 (test-assert (irregex-search "\\x{0041}" "A,"))

--- a/tests/test-irregex-scsh.scm
+++ b/tests/test-irregex-scsh.scm
@@ -8,7 +8,7 @@
 (define test-string 
   "Dieser Test-String wurde am 29.07.2004 um 5:23PM erstellt.\na aa aaa aaaa\nab aabb aaabbb\naba abba abbba\n1 12 123 1234\nyyyyyyyyyy\n")
 
-(test-begin)
+(test-begin "scsh")
 
 (test-assert (not (irregex-search '(: "xxx") test-string)))
 

--- a/tests/test-irregex-utf8.scm
+++ b/tests/test-irregex-utf8.scm
@@ -1,4 +1,4 @@
-(test-begin)
+(test-begin "utf8")
 
 (test-assert (irregex-search "(?u:<..>)" "<漢字>"))
 (test-assert (irregex-search "(?u:<.*>)" "<漢字>"))

--- a/tests/test-irregex.scm
+++ b/tests/test-irregex.scm
@@ -85,7 +85,7 @@
     (else
      (warning "invalid regex test line" line))))
 
-(test-begin)
+(test-begin "irregex")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; basic irregex


### PR DESCRIPTION
The SRFI-64 defines the test-begin form of this shape:

    (test-begin suite-name [count])

Currently all test-begin present in the tests are missing the suite-name, thus failing to conform.  Chicken does accept that, however for example Guile does not.  Therefore this commit adds the suite-name everywhere.  In all instances it is just set to the suffix of the test filename, so it does not really add much information, however it will allow running the tests on SRFI-64 compliant schemes.

* tests/test-cset.scm, tests/test-irregex-from-gauche.scm,
tests/test-irregex-pcre.scm,
tests/test-irregex-scsh.scm,
tests/test-irregex-utf8.scm,
tests/test-irregex.scm: Add the suite-name parameter to test-begin form.