### PR TITLE
tests: Add support for running tests on GNU Guile.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ new-dist.sh
 *.html
 *.tar.gz
 *.tgz
+/tests/*.log

--- a/irregex.scm
+++ b/irregex.scm
@@ -363,7 +363,12 @@
 ;; (define *all-chars* `(/ ,(integer->char (- (char->integer #\space) 32)) ,(integer->char (+ (char->integer #\space) 223))))
 
 ;; set to #f to ignore even an explicit request for utf8 handling
-(define *allow-utf8-mode?* #t)
+;; The utf8-mode is undesired on any implementation with native unicode support.
+;; It is a workaround for those that treat strings as a raw byte sequences, and
+;; does not work well otherwise.  So disable it on implementations known to
+;; handle unicode natively.
+(define *allow-utf8-mode?* (cond-expand ((and chicken (not full-unicode)) #t)
+                                        (else #f)))
 
 ;; (define *named-char-properties* '())
 

--- a/manifest.scm
+++ b/manifest.scm
@@ -1,4 +1,5 @@
 (use-modules (gnu packages chicken)
+             (gnu packages guile)
              (guix build-system chicken)
              (guix download)
              ((guix licenses) #:prefix license:)
@@ -32,4 +33,6 @@ in several modern languages, notably Standard ML, Haskell and Miranda.")
                           chicken
                           chicken-matchable
                           chicken-srfi-1
-                          chicken-test))
+                          chicken-test
+
+                          guile-3.0))

--- a/tests/all
+++ b/tests/all
@@ -14,10 +14,16 @@ cd -- "$root"
 # tests/SCHEME-*.scm glob pattern.
 schemes='
 	chicken
+	guile
 '
 
 interpret_chicken() {
 	csi -s "$@"
+}
+
+interpret_guile() {
+	# While compilation gives better error messages, it is way too slow.
+	guile --no-auto-compile -L . -s "$@"
 }
 
 for scheme in $schemes; do

--- a/tests/guile-cset.scm
+++ b/tests/guile-cset.scm
@@ -1,0 +1,8 @@
+(use-modules (srfi srfi-64))
+
+(set! test-log-to-file "tests/guile-cset.log")
+
+(load-from-path "irregex")
+(load "guile/test-support")
+(load "test-cset")
+(test-exit)

--- a/tests/guile-irregex-from-gauche.scm
+++ b/tests/guile-irregex-from-gauche.scm
@@ -1,0 +1,9 @@
+(use-modules (srfi srfi-64))
+
+(set! test-log-to-file "tests/guile-irregex-from-gauche.log")
+
+(load-from-path "irregex")
+(load-from-path "irregex-utils")
+(load "guile/test-support")
+(load "test-irregex-from-gauche")
+(test-exit)

--- a/tests/guile-irregex-pcre.scm
+++ b/tests/guile-irregex-pcre.scm
@@ -1,0 +1,8 @@
+(use-modules (srfi srfi-64))
+
+(set! test-log-to-file "tests/guile-irregex-pcre.log")
+
+(load-from-path "irregex")
+(load "guile/test-support")
+(load "test-irregex-pcre")
+(test-exit)

--- a/tests/guile-irregex-scsh.scm
+++ b/tests/guile-irregex-scsh.scm
@@ -1,0 +1,8 @@
+(use-modules (srfi srfi-64))
+
+(set! test-log-to-file "tests/guile-irregex-scsh.log")
+
+(load-from-path "irregex")
+(load "guile/test-support")
+(load "test-irregex-scsh")
+(test-exit)

--- a/tests/guile-irregex-utf8.scm
+++ b/tests/guile-irregex-utf8.scm
@@ -1,0 +1,8 @@
+(use-modules (srfi srfi-64))
+
+(set! test-log-to-file "tests/guile-irregex-utf8.log")
+
+(load-from-path "irregex")
+(load "guile/test-support")
+(load "test-irregex-utf8")
+(test-exit)

--- a/tests/guile-irregex.scm
+++ b/tests/guile-irregex.scm
@@ -1,0 +1,19 @@
+(use-modules (ice-9 match)
+             (ice-9 rdelim)
+             (srfi srfi-64))
+
+;;; Implement the bare minimum of chicken's string-split that we need.
+(define %string-split string-split)
+(define (string-split s delim-s keepempty)
+  (if (not keepempty)
+      (error "keepempty: only #t case is implemented"))
+  (if (not (= 1 (string-length delim-s)))
+      (error "Delimiter string can only have a single character"))
+  (%string-split s (string->char-set delim-s)))
+
+(set! test-log-to-file "tests/guile-irregex.log")
+
+(load-from-path "irregex")
+(load "guile/test-support")
+(load "test-irregex")
+(test-exit)

--- a/tests/guile/test-support.scm
+++ b/tests/guile/test-support.scm
@@ -1,0 +1,14 @@
+(if (not (test-runner-current))
+    (test-runner-current (test-runner-create)))
+
+(define (test-exit)
+  (let ((test-runner (test-runner-current)))
+    (exit (if (or (> (test-runner-fail-count test-runner) 0)
+                  (> (test-runner-xpass-count test-runner) 0))
+              #f
+              #t))))
+
+(define-syntax test
+  (syntax-rules ()
+    ((_ exp ...)
+     (test-equal exp ...))))


### PR DESCRIPTION
Straightforward changes, except it did require one change in the library itself, and that is to turn off utf8 parsing support while running under guile.

Based on the information from Alex Shinn, it is useful only for Scheme implementations that do not natively support unicode and instead consider strings to be sequences of bytes, in this case in utf8 encoding.  For others, it is harmful and can break processing of non-ascii text.

You can tell the type of your scheme interpreter by running the following code:

    (display (string-length "é"))
    (newline)
    (display (string-length "あ"))
    (newline)

Guile prints 1 and 1, while chicken 2 and 3.

In the end, the picked solution is to turn it off for everything that is not chicken without full-unicode feature (chicken 6 will support it).

* .gitignore: Ignore the .log files created by Guile's test driver.
* irregex.scm (*allow-utf8-mode?*): Set to #f for everything except chicken < 6.
* manifest.scm: Add guile.
* tests/all (schemes): Register guile.
(interpret_guile): New function.  Run the guile with no auto-compilation due to
the startup cost.
* tests/guile-cset.scm, tests/guile-irregex-from-gauche.scm,
tests/guile-irregex-pcre.scm,
tests/guile-irregex-scsh.scm,
tests/guile-irregex-utf8.scm,
tests/guile-irregex.scm,
tests/guile/test-support.scm: New files.