### PR TITLE
irregex-guile: Drop the extension from the load-from-path call.

### DIFF
--- a/irregex-guile.scm
+++ b/irregex-guile.scm
@@ -17,4 +17,4 @@
 	    irregex-nfa irregex-flags irregex-lengths irregex-names
             irregex-num-submatches irregex-extract irregex-split))
 
-(load-from-path "rx/source/irregex.scm")
+(load-from-path "rx/source/irregex")


### PR DESCRIPTION
When GNU Guile tries to load a file using load-from-path, it tries to locate a compiled version of the file by looking into %load-compiled-path using %load-compiled-extensions.

At the same time, when guile code is compiled, it is usually saved into a file with .go extension, therefore irregex.scm becomes irregex.go.

Putting these two together, we can see why the loading of the library using "rx/source/irregex.scm" is problematic.  It looks for the compiled version using "rx/source/irregex.scm.go" filename, which will not be present.

The fix is to simply remove the .scm, it will be tried automatically thanks to the default value of %load-extensions.

* irregex-guile.scm: Drop the .scm from load-from-path.