### PR TITLE
tests: Add support for running tests on Gauche.

### DIFF
--- a/irregex.scm
+++ b/irregex.scm
@@ -2215,7 +2215,8 @@
      . (or alphanumeric punctuation #\$ #\+ #\< #\= #\> #\^ #\` #\| #\~))
     (graph . graphic)
     (blank . (or #\space ,(integer->char (- (char->integer #\space) 23))))
-    (whitespace . (or blank #\newline #\page #\return #\vtab))
+    ;; 0B - vertical tab, 0C - form feed
+    (whitespace . (or blank #\newline #\x0C #\return #\x0B))
     (space . whitespace)
     (white . whitespace)
     (printing . (or graphic whitespace))

--- a/manifest.scm
+++ b/manifest.scm
@@ -1,5 +1,6 @@
 (use-modules (gnu packages chicken)
              (gnu packages guile)
+             (gnu packages scheme)
              (guix build-system chicken)
              (guix download)
              ((guix licenses) #:prefix license:)
@@ -34,5 +35,7 @@ in several modern languages, notably Standard ML, Haskell and Miranda.")
                           chicken-matchable
                           chicken-srfi-1
                           chicken-test
+
+                          gauche
 
                           guile-3.0))

--- a/tests/all
+++ b/tests/all
@@ -14,11 +14,16 @@ cd -- "$root"
 # tests/SCHEME-*.scm glob pattern.
 schemes='
 	chicken
+	gauche
 	guile
 '
 
 interpret_chicken() {
 	csi -s "$@"
+}
+
+interpret_gauche() {
+	gosh -I. -Itests "$@"
 }
 
 interpret_guile() {

--- a/tests/gauche-cset.scm
+++ b/tests/gauche-cset.scm
@@ -1,0 +1,8 @@
+(use srfi.64)
+
+(set! test-log-to-file "tests/gauche-cset.log")
+
+(load "irregex.scm")
+(load "gauche/test-support.scm")
+(load "test-cset.scm")
+(test-exit)

--- a/tests/gauche-irregex-from-gauche.scm
+++ b/tests/gauche-irregex-from-gauche.scm
@@ -1,0 +1,9 @@
+(use srfi.64)
+
+(set! test-log-to-file "tests/gauche-irregex-from-gauche.log")
+
+(load "irregex.scm")
+(load "irregex-utils.scm")
+(load "gauche/test-support.scm")
+(load "test-irregex-from-gauche.scm")
+(test-exit)

--- a/tests/gauche-irregex-pcre.scm
+++ b/tests/gauche-irregex-pcre.scm
@@ -1,0 +1,8 @@
+(use srfi.64)
+
+(set! test-log-to-file "tests/gauche-irregex-pcre.log")
+
+(load "irregex.scm")
+(load "gauche/test-support.scm")
+(load "test-irregex-pcre.scm")
+(test-exit)

--- a/tests/gauche-irregex-scsh.scm
+++ b/tests/gauche-irregex-scsh.scm
@@ -1,0 +1,8 @@
+(use srfi.64)
+
+(set! test-log-to-file "tests/gauche-irregex-scsh.log")
+
+(load "irregex.scm")
+(load "gauche/test-support.scm")
+(load "test-irregex-scsh.scm")
+(test-exit)

--- a/tests/gauche-irregex-utf8.scm
+++ b/tests/gauche-irregex-utf8.scm
@@ -1,0 +1,8 @@
+(use srfi.64)
+
+(set! test-log-to-file "tests/gauche-irregex-utf8.log")
+
+(load "irregex.scm")
+(load "gauche/test-support.scm")
+(load "test-irregex-utf8.scm")
+(test-exit)

--- a/tests/gauche-irregex.scm
+++ b/tests/gauche-irregex.scm
@@ -1,0 +1,16 @@
+(use srfi.64)
+(use util.match)
+
+;;; Implement the bare minimum of chicken's string-split that we need.
+(define %string-split string-split)
+(define (string-split s delim-s keepempty)
+  (if (not keepempty)
+      (error "keepempty: only #t case is implemented"))
+  (%string-split s delim-s))
+
+(set! test-log-to-file "tests/gauche-irregex.log")
+
+(load "irregex.scm")
+(load "gauche/test-support.scm")
+(load "test-irregex.scm")
+(test-exit)

--- a/tests/gauche/test-support.scm
+++ b/tests/gauche/test-support.scm
@@ -1,0 +1,14 @@
+(if (not (test-runner-current))
+    (test-runner-current (test-runner-create)))
+
+(define (test-exit)
+  (let ((test-runner (test-runner-current)))
+    (exit (if (or (> (test-runner-fail-count test-runner) 0)
+                  (> (test-runner-xpass-count test-runner) 0))
+              #f
+              #t))))
+
+(define-syntax test
+  (syntax-rules ()
+    ((_ exp ...)
+     (test-equal exp ...))))


### PR DESCRIPTION
Required changing the definition of `whitespace', since #\page and #\vtab are not recognized by gauche (nor by R7RS).

* irregex.scm (sre-named-definitions): Use #\x0C for #\page and #\x0B for #\vtab to respect the list of character names mandated by R7RS.
* manifest.scm: Add gauche.
* tests/all (schemes): Register gauche. (interpret_gauche): New function.
* tests/gauche-cset.scm, tests/gauche-irregex-from-gauche.scm,
tests/gauche-irregex-pcre.scm,
tests/gauche-irregex-scsh.scm,
tests/gauche-irregex-utf8.scm,
tests/gauche-irregex.scm,
tests/gauche/test-support.scm: New files.