### PR TITLE
tests: Add support for running tests on Chibi.

### DIFF
--- a/manifest.scm
+++ b/manifest.scm
@@ -31,6 +31,8 @@ in several modern languages, notably Standard ML, Haskell and Miranda.")
 
 (packages->manifest (list coreutils
 
+                          chibi-scheme
+
                           chicken
                           chicken-matchable
                           chicken-srfi-1

--- a/tests/all
+++ b/tests/all
@@ -13,10 +13,15 @@ cd -- "$root"
 # The script will execute interpret_SCHEME function for every file matching the
 # tests/SCHEME-*.scm glob pattern.
 schemes='
+	chibi
 	chicken
 	gauche
 	guile
 '
+
+interpret_chibi() {
+	chibi-scheme -I. -Itests "$@"
+}
 
 interpret_chicken() {
 	csi -s "$@"

--- a/tests/chibi-cset.scm
+++ b/tests/chibi-cset.scm
@@ -1,0 +1,7 @@
+(import (chibi test)
+        (scheme small)
+        (scheme r5rs))
+
+(load "irregex.scm")
+(load "tests/test-cset.scm")
+(test-exit)

--- a/tests/chibi-irregex-from-gauche.scm
+++ b/tests/chibi-irregex-from-gauche.scm
@@ -1,0 +1,9 @@
+(import (chibi test)
+        (scheme small)
+        (scheme r5rs)
+        (srfi 1))
+
+(load "irregex.scm")
+(load "irregex-utils.scm")
+(load "tests/test-irregex-from-gauche.scm")
+(test-exit)

--- a/tests/chibi-irregex-pcre.scm
+++ b/tests/chibi-irregex-pcre.scm
@@ -1,0 +1,7 @@
+(import (chibi test)
+        (scheme small)
+        (scheme r5rs))
+
+(load "irregex.scm")
+(load "tests/test-irregex-pcre.scm")
+(test-exit)

--- a/tests/chibi-irregex-scsh.scm
+++ b/tests/chibi-irregex-scsh.scm
@@ -1,0 +1,7 @@
+(import (chibi test)
+        (scheme small)
+        (scheme r5rs))
+
+(load "irregex.scm")
+(load "tests/test-irregex-scsh.scm")
+(test-exit)

--- a/tests/chibi-irregex-utf8.scm
+++ b/tests/chibi-irregex-utf8.scm
@@ -1,0 +1,7 @@
+(import (chibi test)
+        (scheme small)
+        (scheme r5rs))
+
+(load "irregex.scm")
+(load "tests/test-irregex-utf8.scm")
+(test-exit)

--- a/tests/chibi-irregex.scm
+++ b/tests/chibi-irregex.scm
@@ -1,0 +1,9 @@
+(import (chibi match)
+        (chibi test)
+        (scheme small)
+        (scheme r5rs)
+        (srfi 130))
+
+(load "irregex.scm")
+(load "tests/test-irregex.scm")
+(test-exit)


### PR DESCRIPTION
* manifest.scm: Add chibi-scheme.
* tests/all (schemes): Register chibi. (interpret_chibi): New function.
* tests/chibi-cset.scm, tests/chibi-irregex-from-gauche.scm,
tests/chibi-irregex-pcre.scm,
tests/chibi-irregex-scsh.scm,
tests/chibi-irregex-utf8.scm,
tests/chibi-irregex.scm: New files.