### PR TITLE
fix chezscheme: import (srfi :0 cond-expand)

### DIFF
--- a/irregex-utils.chezscheme.sls
+++ b/irregex-utils.chezscheme.sls
@@ -31,6 +31,7 @@
    irregex-opt
    sre->string)
   (import 
+    (srfi :0 cond-expand)
     (except (rnrs) error find filter remove)
     (only (chezscheme) include get-output-string open-output-string)
     (irregex)

--- a/irregex.chezscheme.sls
+++ b/irregex.chezscheme.sls
@@ -66,6 +66,7 @@
     irregex-split
     sre->cset)
   (import 
+    (srfi :0 cond-expand)
     (except (rnrs) error find filter remove)
     (rnrs r5rs)
     (rnrs mutable-pairs)


### PR DESCRIPTION
Running
```
make CHEZ=scheme PREFIX=$HOME/.local chez-build
```
produces the following exception:
```
Exception: attempt to reference unbound identifier cond-expand at line 371, char 29 of irregex.scm
```
This PR fixes the issue for me (having srfi 0 somewhere in CHEZSCHEMELIBDIRS).